### PR TITLE
fix: Make all the signup tests pass.

### DIFF
--- a/entrysystem-backend/src/main/java/com/entry/entrydsm/grade/domain/Score.java
+++ b/entrysystem-backend/src/main/java/com/entry/entrydsm/grade/domain/Score.java
@@ -36,7 +36,7 @@ public abstract class Score extends BaseTimeEntity {
     @Column(nullable = false)
     private Double volunteerScore;
 
-    @Column(nullable = false, insertable = false, updatable = false)
+    @Column(insertable = false, updatable = false)
     private Double finalScore;
 
     public Score(User user, int attendanceScore) {

--- a/entrysystem-backend/src/main/java/com/entry/entrydsm/user/domain/User.java
+++ b/entrysystem-backend/src/main/java/com/entry/entrydsm/user/domain/User.java
@@ -108,13 +108,8 @@ public class User extends BaseTimeEntity {
 
 
     public User(TempUser tempUser) {
-        this.email = tempUser.getEmail();
-        this.password = tempUser.getPassword();
-        this.graduateType = GraduateType.WILL;
-        this.region = false;
-        this.admission = Admission.NORMAL;
-        this.admissionDetail = AdmissionDetail.NONE;
-        this.additionalType = AdditionalType.NONE;
+        this(tempUser.getEmail(), tempUser.getPassword(), GraduateType.WILL, Admission.NORMAL,
+                AdmissionDetail.NONE, false, AdditionalType.NONE);
     }
 
     @Builder
@@ -126,6 +121,7 @@ public class User extends BaseTimeEntity {
         this.admission = (admission == null) ? Admission.NORMAL : admission;
         this.admissionDetail = (this.admission == Admission.SOCIAL && admissionDetail != null) ? admissionDetail : AdmissionDetail.NONE;
         this.additionalType = (additionalType == null) ? AdditionalType.NONE : additionalType;
+        initialize();
     }
 
     @Override
@@ -171,7 +167,7 @@ public class User extends BaseTimeEntity {
         }
     }
 
-    public void initialize() {
+    private void initialize() {
         this.info = new Info(this);
         this.graduateInfo = new GraduateInfo(this);
         this.grades = new ArrayList<>();

--- a/entrysystem-backend/src/main/java/com/entry/entrydsm/user/service/AuthService.java
+++ b/entrysystem-backend/src/main/java/com/entry/entrydsm/user/service/AuthService.java
@@ -74,7 +74,6 @@ public class AuthService {
         TempUser tempUser = tempUserRepository.findById(code).orElseThrow(() -> new BadRequestException("올바르지 않은 인증 코드입니다."));
         User user = new User(tempUser);
         tempUserRepository.delete(tempUser);
-        user.initialize();
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
- Make score.finalScore nullable
We use H2 database while testing, but h2 database doesn't know
finalScore is generated column.
We can not save the score entity with NULL finalScore, so we should to make
that nullable.
- Make User.initialize method private. and call it in constructors