### PR TITLE
fix: Fix build failing

### DIFF
--- a/entrysystem-backend/src/main/resources/application-production.properties
+++ b/entrysystem-backend/src/main/resources/application-production.properties
@@ -2,7 +2,5 @@
 spring.datasource.url=jdbc:${ENTRY_DB_URL}?allowPublicKeyRetrieval=true&useSSL=false&useUnicode=true&characterEncoding=utf8
 spring.datasource.username=${ENTRY_DB_USERNAME}
 spring.datasource.password=${ENTRY_DB_PASSWORD}
-spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform=org.hibernate.dialect.MySQL5InnoDBDialect
 # hibernate
-spring.jpa.hibernate.ddl-auto=validate


### PR DESCRIPTION
- remove spring.jpa.hibernate.ddl-auto property
ref: https://hibernate.atlassian.net/browse/HHH-2354
spring.jpa.hibernate.ddl-auto=validate option validate not completely.
Don't allow enum, only varchar allowed. so I removed this option.
- remove spring.datasource.driverClassName property